### PR TITLE
Bug 1584178 - Pass the starting and ending position of a placeable to…

### DIFF
--- a/src/createMarker.ts
+++ b/src/createMarker.ts
@@ -16,8 +16,8 @@ type Props = {
  * that it has a `key` attribute.
  */
 function enhanceTag(tag: TagFunction) {
-    return (x: string) => {
-        const elt = tag(x);
+    return (input: string, startPos: number, endPos: number) => {
+        const elt = tag(input, startPos, endPos);
         return React.cloneElement(elt, { key: shortid.generate() });
     };
 }

--- a/src/markRegExp.test.tsx
+++ b/src/markRegExp.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import markRegExp from './markRegExp';
+import markTerm from "./markTerm";
 
 
 describe('markRegExp', () => {
@@ -113,5 +114,42 @@ describe('markRegExp', () => {
             '.',
         ];
         expect(res).toEqual(expected);
+    });
+
+
+    it('pass the position of a placeable', () => {
+        const content = 'A horse, a horse, my kingdom for a horse and another kingdom.';
+        const tagMock = jest.fn(x => <mark>{x}</mark>)
+        const regex = /(another|kingdom)/;
+        const placeholder1 = "another"
+        const placeholder2 = "kingdom"
+
+        const res = markRegExp(content, regex, tagMock);
+        const expected = [
+            'A horse, a horse, my ',
+            <mark>{'kingdom'}</mark>,
+            ' for a horse and ',
+            <mark>{'another'}</mark>,
+            ' ',
+            <mark>{'kingdom'}</mark>,
+            '.'
+        ]
+        expect(res).toEqual(expected);
+        expect(tagMock.mock.calls.length).toBe(3);
+        expect(tagMock.mock.calls[0]).toEqual([placeholder2, 21, 28])
+        expect(tagMock.mock.calls[1]).toEqual([placeholder1, 45, 52])
+        expect(tagMock.mock.calls[2]).toEqual([placeholder2, 53, 60])
+
+        let [, startPos, endPos] = tagMock.mock.calls[0];
+        expect(endPos - startPos).toEqual(placeholder2.length);
+        expect(content.substring(startPos, endPos)).toEqual(placeholder2);
+
+        [, startPos, endPos] = tagMock.mock.calls[1];
+        expect(endPos - startPos).toEqual(placeholder1.length);
+        expect(content.substring(startPos, endPos)).toEqual(placeholder1);
+
+        [, startPos, endPos] = tagMock.mock.calls[2];
+        expect(endPos - startPos).toEqual(placeholder2.length);
+        expect(content.substring(startPos, endPos)).toEqual(placeholder2);
     });
 });

--- a/src/markRegExp.ts
+++ b/src/markRegExp.ts
@@ -30,8 +30,9 @@ export default function markRegExp(
     const output:React.ReactNodeArray = [];
     let remaining = content;
     let matches = rule.exec(remaining);
-
+    let startPos = 0;
     while (matches) {
+        startPos += matches.index
         let match;
         if (typeof matchIndex !== 'undefined' && matchIndex !== null) {
             match = matches[matchIndex];
@@ -41,7 +42,6 @@ export default function markRegExp(
             // capture groups in the rule.
             match = matches.reduce((acc, cur) => cur || acc, '');
         }
-
         // Take only the part that can contain the match.
         const matchingContent = remaining.slice(matches.index);
         // Then split only that part.
@@ -59,7 +59,9 @@ export default function markRegExp(
         if (beginning) {
             output.push(beginning);
         }
-        output.push(tag(match));
+
+        output.push(tag(match, startPos, startPos+match.length));
+        startPos += match.length;
 
         // Compute the next step.
         matches = rule.exec(remaining);

--- a/src/markTerm.test.tsx
+++ b/src/markTerm.test.tsx
@@ -73,4 +73,22 @@ describe('markTerm', () => {
         const expected = [content];
         expect(res).toEqual(expected);
     });
+
+    it('pass the position of a placeable', () => {
+        const content = 'A horse, a horse, my kingdom for a horse and another kingdom.';
+        const tagMock = jest.fn(x => <mark>{x}</mark>)
+        const placeholder  = "kingdom"
+        markTerm(content, placeholder, tagMock);
+        expect(tagMock.mock.calls.length).toBe(2);
+        expect(tagMock.mock.calls[0]).toEqual([placeholder, 21, 28])
+        expect(tagMock.mock.calls[1]).toEqual([placeholder, 53, 60])
+
+        let [, startPos, endPos] = tagMock.mock.calls[0];
+        expect(endPos - startPos).toEqual(placeholder.length);
+        expect(content.substring(startPos, endPos)).toEqual(placeholder);
+
+        [, startPos, endPos] = tagMock.mock.calls[1];
+        expect(endPos - startPos).toEqual(placeholder.length);
+        expect(content.substring(startPos, endPos)).toEqual(placeholder);
+    });
 });

--- a/src/markTerm.ts
+++ b/src/markTerm.ts
@@ -34,15 +34,21 @@ export default function markTerm(
 
     const parts = content.split(term);
 
-    for (let i = 0; i < parts.length - 1; i++) {
+    let lastIndex = parts.length -1;
+    let startPos = 0;
+
+    for (let i = 0; i < lastIndex; i++) {
         if (parts[i]) {
+            startPos += parts[i].length
             output.push(parts[i]);
         }
-        output.push(tag(term));
+
+        output.push(tag(term, startPos, startPos + term.length));
+        startPos += term.length;
     }
 
-    if (parts[parts.length - 1]) {
-        output.push(parts[parts.length - 1]);
+    if (parts[lastIndex]) {
+        output.push(parts[lastIndex]);
     }
 
     return output;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-export type TagFunction = (input: string) => React.ReactElement<any>;
+export type TagFunction = (input: string, startPos: number, endPos: number) => React.ReactElement<any>;
 
 export type Parser = {
     rule: string | RegExp;


### PR DESCRIPTION
I've noticed that GAT (Google Translator API) wraps placeables with additional spaces in their API responses.
When a translator wants to translate which contains a placeable e.g.
```
<strong>something</strong>

```
GAT returns as:

```html
<strong> something </strong>
```

This behavior has been reported as a bug on the GAT bug-tracker.
One of the possible fixes to this issue is to post-process responses from GAT and remove unnecessary spaces. One of the ideas was to detect the positions of placements in the original string and verify if they're surrounded by spaces or not. This would also work after GAT changes its API.

I've decided to change the tagging functions and add two additional parameters about the starting/ending position of a placeable, in order to later use that in Pontoon. This would help with adjusting strings from GAT to their original forms (by e.g. removing unnecessary spaces).
Unfortunately, the change is backward incompatible and may affect other users of this library.

Related:
* [Bug 1584178](https://bugzilla.mozilla.org/show_bug.cgi?id=1584178)

@mathjazz @Pike can you take a look?