### PR TITLE
Add parser for Mozilla printf string syntax placeables

### DIFF
--- a/src/getRules.ts
+++ b/src/getRules.ts
@@ -11,6 +11,7 @@ import { fluentTerm } from './parsers/fluentTerm';
 import { javaFormattingVariable } from './parsers/javaFormattingVariable';
 import { jsonPlaceholder } from './parsers/jsonPlaceholder';
 import { leadingSpace } from './parsers/leadingSpace';
+import { mozillaPrintfPattern } from './parsers/mozillaPrintfPattern';
 import { multipleSpaces } from './parsers/multipleSpaces';
 import { narrowNonBreakingSpace } from './parsers/narrowNonBreakingSpace';
 import { newlineCharacter } from './parsers/newlineCharacter';
@@ -109,7 +110,9 @@ export function getRules(opt?: {
         camelCaseString,
         optionPattern,
         punctuation,
-        numberString
+        numberString,
+
+        mozillaPrintfPattern,
     );
 
     return rules;

--- a/src/parsers/mozillaPrintfPattern.test.tsx
+++ b/src/parsers/mozillaPrintfPattern.test.tsx
@@ -1,0 +1,20 @@
+import { render } from '@testing-library/react';
+import each from 'jest-each';
+import { createMarker } from '../createMarker';
+
+import { mozillaPrintfPattern } from './mozillaPrintfPattern';
+
+describe('mozillaPrintfPattern', () => {
+    each([
+        ['%S', 'My %S is Luka.'],
+        ['%1$S', 'My %1$S is Luka.'],
+        ['%@', 'My %@ is Luka.'],
+        ['%2$@', 'My %2$@ is Luka.'],
+    ]).it('marks `%s` in `%s`', (mark, content) => {
+        const Marker = createMarker([mozillaPrintfPattern]);
+        const { container } = render(<Marker>{content}</Marker>);
+        const marks = container.querySelectorAll('mark');
+        expect(marks).toHaveLength(1);
+        expect(marks[0].textContent).toEqual(mark);
+    });
+});

--- a/src/parsers/mozillaPrintfPattern.tsx
+++ b/src/parsers/mozillaPrintfPattern.tsx
@@ -1,0 +1,21 @@
+import type { Parser } from '../index';
+
+/**
+ * Marks placeables in the format of Mozilla's printf string syntax.
+ * 
+ * Example matches:
+ *
+ *   %S
+ *   %1$S
+ *   %@
+ *   %2$@
+ */
+export const mozillaPrintfPattern: Parser = {
+    rule: /%(?:[1-9]\$)?[S@]/,
+    matchIndex: 0,
+    tag: x => (
+        <mark data-mark="mozillaPrintfPattern" title="Placeable">
+            {x}
+        </mark>
+    ),
+};


### PR DESCRIPTION
Addresses https://github.com/mozilla/pontoon/issues/2515.

This PR introduces a new feature to the react-content-marker library, adding the ability to parse and mark Mozilla's printf string syntax placeables within the source strings.

The new parser, mozillaPrintfPattern, identifies the following types of placeholders: `"%S"`, `"%1$S"`, `"%"@`, and `"%2$@"`. This feature enhances the Pontoon interface by allowing users to click on a placeholder in the source string, subsequently reproducing it in the localized view.

I have added the following files:

1. `mozillaPrintfPattern.tsx`: This file contains the parser rules to identify and mark the placeholders in Mozilla's printf string syntax.

2. `mozillaPrintfPattern.test.tsx`: This file contains unit tests to verify the correct functioning of the new parser. 

This feature was developed to address the usability issue faced by the translators while working with the Pontoon interface. The clickable placeholders not only minimize the chance of typos but also enhance the overall translation workflow.